### PR TITLE
onclick ignored for mobile devices

### DIFF
--- a/layout/js/animate.js
+++ b/layout/js/animate.js
@@ -126,6 +126,11 @@ function setNormal(id){
   var className = id.split('-')[0];
   document.getElementById(id).setAttribute('class', className);
 }
-function openNWIS(id){
+function openNWIS(id, event){
+ if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+   event.stopPropagation();
+}else{
   window.open('http://waterdata.usgs.gov/nwis/uv?site_no='+id,'_blank');
+  }
+  
 }


### PR DESCRIPTION
@jiwalker-usgs this seem like a legit solution?

the onclick is stopped on both my android phone and the office ipad, but goes through on my laptop. So seems like exactly what we need.