### PR TITLE
proposal for some shared svg mapping utils

### DIFF
--- a/scripts/visualize/visualize.harvey_map.R
+++ b/scripts/visualize/visualize.harvey_map.R
@@ -2,6 +2,36 @@
 # viz <- viz$visualize
 # viz <- viz[[which(unlist((lapply(viz, function(x) x$id == "harvey-map"))))]]
 
+visualize.svg_base_map <- function(viz){
+  geoms <- readDepends(viz)
+  library(svglite)
+  
+  # 1) set up shell svg, w/ proper size and aspect
+  # 2) add basic groups etc, including <defs><g id="template-geoms"/></defs> and <g id="styled-geoms"/>
+  # 3) set the plot bounds, including aspect of map
+  # 4) read in depends geoms
+  # 5) loop through depends, trim, then add geoms to <use/> elements (in id="template-geoms"), with id="u-{id}"
+  # 6) create geoms to mirror ids in <use/> elements, add attributes
+}
+get_sp_bbox <- function(sp){
+  bb <- bbox(sp)
+  Sr1 <- Polygon(cbind(c(bb[1, 3, 3, 1, 1]), c(bb[2, 2, 4, 4, 2])))
+  Srs1 <- Polygons(list(Sr1), "s1")
+  SpP <- SpatialPolygons(list(Srs1), proj4string = CRS(proj4string(sp)))
+  return(SpP)
+}
+
+get_sp_lims <- function(sp, ...){
+  bb <- get_sp_bbox(sp)
+  # now default plot
+  # extract usr, return lims from usr
+  .fun <- svglite::svgstring(standalone = F, ...)
+  usr <- par('usr')
+  rm(.fun)
+  
+  return(list(xlim = usr[c(1,2)], ylim = usr[c(3,4)]))
+}
+
 visualize.harvey_map <- function(viz = as.viz("harvey-map")){
   
   counties <- readData(viz[['depends']][1])

--- a/scripts/visualize/visualize.harvey_map.R
+++ b/scripts/visualize/visualize.harvey_map.R
@@ -1,36 +1,4 @@
-# viz <- yaml.load_file("viz.yaml")
-# viz <- viz$visualize
-# viz <- viz[[which(unlist((lapply(viz, function(x) x$id == "harvey-map"))))]]
 
-visualize.svg_base_map <- function(viz){
-  geoms <- readDepends(viz)
-  library(svglite)
-  
-  # 1) set up shell svg, w/ proper size and aspect
-  # 2) add basic groups etc, including <defs><g id="template-geoms"/></defs> and <g id="styled-geoms"/>
-  # 3) set the plot bounds, including aspect of map
-  # 4) read in depends geoms
-  # 5) loop through depends, trim, then add geoms to <use/> elements (in id="template-geoms"), with id="u-{id}"
-  # 6) create geoms to mirror ids in <use/> elements, add attributes
-}
-get_sp_bbox <- function(sp){
-  bb <- bbox(sp)
-  Sr1 <- Polygon(cbind(c(bb[1, 3, 3, 1, 1]), c(bb[2, 2, 4, 4, 2])))
-  Srs1 <- Polygons(list(Sr1), "s1")
-  SpP <- SpatialPolygons(list(Srs1), proj4string = CRS(proj4string(sp)))
-  return(SpP)
-}
-
-get_sp_lims <- function(sp, ...){
-  bb <- get_sp_bbox(sp)
-  # now default plot
-  # extract usr, return lims from usr
-  .fun <- svglite::svgstring(standalone = F, ...)
-  usr <- par('usr')
-  rm(.fun)
-  
-  return(list(xlim = usr[c(1,2)], ylim = usr[c(3,4)]))
-}
 
 visualize.harvey_map <- function(viz = as.viz("harvey-map")){
   
@@ -47,6 +15,8 @@ visualize.harvey_map <- function(viz = as.viz("harvey-map")){
   non.harvey.gages <- readData(viz[['depends']][11])
   library(svglite)
   library(dplyr)
+  
+  
   
   set.plot <- function(){
     par(mai=c(0,0,0,0), omi=c(0,0,0,0), xaxs = 'i', yaxs = 'i')

--- a/scripts/visualize/visualize_utils.R
+++ b/scripts/visualize/visualize_utils.R
@@ -1,0 +1,71 @@
+
+visualize.svg_base_map <- function(viz){
+  geoms <- readDepends(viz)
+  library(svglite)
+  
+  # 1) set up shell svg, w/ proper size and aspect
+  # 2) add basic groups etc, including <defs><g id="template-geoms"/></defs> and <g id="styled-geoms"/>
+  # 3) set the plot bounds, including aspect of map
+  # 4) read in depends geoms
+  # 5) loop through depends, trim, then add geoms to <use/> elements (in id="template-geoms"), with id="u-{id}"
+  # 6) create geoms to mirror ids in <use/> elements, add attributes
+}
+get_sp_bbox <- function(sp){
+  bb <- bbox(sp)
+  Sr1 <- Polygon(cbind(c(bb[c(1, 3, 3, 1, 1)]), c(bb[c(2, 2, 4, 4, 2)])))
+  Srs1 <- Polygons(list(Sr1), "s1")
+  SpP <- SpatialPolygons(list(Srs1), proj4string = CRS(proj4string(sp)))
+  return(SpP)
+}
+
+get_svg_geoms <- function(sp, ..., width = 10, height = 8, pointsize = 12, xlim, ylim){
+  
+  stopifnot(packageVersion('svglite') == '1.2.0.9002')
+  
+  if (missing(xlim)){
+    xlim <- get_sp_lims(sp, ..., return = 'xlim')
+  }
+  if (missing(ylim)){
+    ylim <- get_sp_lims(sp, ..., return = 'ylim')
+  }
+  
+  geoms <- xml2::xml_new_document()
+  
+  
+  rendered <- svglite::xmlSVG(width = width, height = height, pointsize = pointsize, standalone = F, {
+    set_sp_plot()
+    plot(sp, ..., xlim = xlim, ylim = ylim)
+  })
+  
+  
+  return(tail(xml_children(rendered), length(sp))) # removing the <rect/> element...
+}
+
+get_sp_lims <- function(sp, ..., width = 10, height = 8, pointsize = 12, return = c('xlim','ylim')){
+  bb <- get_sp_bbox(sp)
+  # now default plot
+  # extract usr, return lims from usr
+  .fun <- svglite::svgstring(width = width, height = height, pointsize = pointsize, standalone = F)
+  suppressWarnings(plot(bb, ...)) # warning is for expandBB param, if used
+  usr <- par('usr')
+  dev.off()
+  xlim = usr[c(1,2)]
+  ylim = usr[c(3,4)]
+  
+  list.out <- list(xlim = xlim, ylim = ylim)
+  
+  if (length(return) > 1){
+    return(list.out)
+  } else {
+    return(list.out[[return]])
+  }
+  
+}
+
+clip_sp <- function(sp, clip.box){
+  message('not implemented yet')
+}
+
+set_sp_plot <- function(){
+  par(mai=c(0,0,0,0), omi=c(0,0,0,0), xaxs = 'i', yaxs = 'i')
+}

--- a/scripts/visualize/visualize_utils.R
+++ b/scripts/visualize/visualize_utils.R
@@ -10,6 +10,11 @@ visualize.svg_base_map <- function(viz){
   # 5) loop through depends, trim, then add geoms to <use/> elements (in id="template-geoms"), with id="u-{id}"
   # 6) create geoms to mirror ids in <use/> elements, add attributes
 }
+
+#' calculate the bounding box of the sp object and return as `SpatialPolygons` object
+#' @param sp a spatial object
+#' 
+#' @return a `SpatialPolygons` object that represents the bounding box of the input `sp`
 get_sp_bbox <- function(sp){
   bb <- bbox(sp)
   Sr1 <- Polygon(cbind(c(bb[c(1, 3, 3, 1, 1)]), c(bb[c(2, 2, 4, 4, 2)])))
@@ -18,6 +23,18 @@ get_sp_bbox <- function(sp){
   return(SpP)
 }
 
+
+#' extract the svg elements from an sp object
+#' 
+#' @param sp a spatial object
+#' @param ... additional arguments passed to the plotting methods of `sp` (e.g., `expandBB`)
+#' @param width the width (in inches) of the svg view
+#' @param height the height (in inches) of the svg view
+#' @param pointsize number of pixels per inch
+#' @param xlim x limits (in sp units) of the plot
+#' @param ylim y limits (in sp units) of the plot
+#' 
+#' @return an `xml_document`
 get_svg_geoms <- function(sp, ..., width = 10, height = 8, pointsize = 12, xlim, ylim){
   
   stopifnot(packageVersion('svglite') == '1.2.0.9002')
@@ -29,17 +46,34 @@ get_svg_geoms <- function(sp, ..., width = 10, height = 8, pointsize = 12, xlim,
     ylim <- get_sp_lims(sp, ..., return = 'ylim')
   }
   
-  geoms <- xml2::xml_new_document()
+  # clip the spatial object so that it only contains features and data that are within the plotting range:
+  clipped.sp <- clip_sp(sp, xlim, ylim)
   
+  # establish the holder of the geoms as an xml doc
+  geoms <- xml2::xml_new_document()
   
   rendered <- svglite::xmlSVG(width = width, height = height, pointsize = pointsize, standalone = F, {
     set_sp_plot()
-    plot(sp, ..., xlim = xlim, ylim = ylim)
+    plot(clipped.sp, ..., xlim = xlim, ylim = ylim)
   })
   
+  sp.geoms <- tail(xml2::xml_children(rendered), length(sp))
   
-  return(tail(xml_children(rendered), length(sp))) # removing the <rect/> element...
+  # here either strip the important attributes out and re-add them with a xml_set_attrs call, or lapply the nodeset and add attrs one by one:
+  
+  return(sp.geoms) # removing the <rect/> element...
 }
+
+#' extract the plotting limits from a spatial object, given a sized svg view
+#' 
+#' @param sp a spatial object
+#' @param ... additional arguments passed to the plotting methods of `sp` (e.g., `expandBB`)
+#' @param width the width (in inches) of the svg view
+#' @param height the height (in inches) of the svg view
+#' @param pointsize number of pixels per inch
+#' @param return what limits to return
+#' 
+#' @return a list or numeric vector, depending on what is specified for `return`
 
 get_sp_lims <- function(sp, ..., width = 10, height = 8, pointsize = 12, return = c('xlim','ylim')){
   bb <- get_sp_bbox(sp)
@@ -62,10 +96,21 @@ get_sp_lims <- function(sp, ..., width = 10, height = 8, pointsize = 12, return 
   
 }
 
-clip_sp <- function(sp, clip.box){
-  message('not implemented yet')
+#' retain data and features for all polys/points within the plotting range,
+#' while removing those outsite and truncating the boundaries of 
+#' polygons to the bounds of the plotting range. 
+#' 
+#' @param sp a spatial object
+#' @param xlim the x limits of the plot using the same coordinate system as `sp`
+#' @param ylim the y limits of the plot using the same coordinate system as `sp`
+#' 
+#' @return a clipped sp object
+clip_sp <- function(sp, xlim, ylim){
+  message('clip_sp is not implemented yet')
+  return(sp)
 }
 
+#' set up the basic plot par for a map
 set_sp_plot <- function(){
   par(mai=c(0,0,0,0), omi=c(0,0,0,0), xaxs = 'i', yaxs = 'i')
 }

--- a/scripts/visualize/visualize_utils.R
+++ b/scripts/visualize/visualize_utils.R
@@ -106,10 +106,17 @@ get_sp_lims <- function(sp, ..., width = 10, height = 8, pointsize = 12, return 
 #' @param sp a spatial object
 #' @param xlim the x limits of the plot using the same coordinate system as `sp`
 #' @param ylim the y limits of the plot using the same coordinate system as `sp`
+#' @param ... additional args (unused)
 #' 
 #' @return a clipped sp object
-clip_sp <- function(sp, xlim, ylim){
+#' @export
+clip_sp <- function(sp, xlim, ylim, ...) {
   message('clip_sp is not fully implemented for all sp classes')
+  UseMethod(generic = 'clip_sp', object = sp)
+}
+
+
+clip_sp.SpatialPolygonsDataFrame <- function(sp, xlim, ylim, ...){
   
   clip <- as.sp_box(xlim, ylim, CRS(proj4string(sp)))
   g.i <- rgeos::gIntersects(sp, clip, byid = T) 

--- a/scripts/visualize/visualize_utils.R
+++ b/scripts/visualize/visualize_utils.R
@@ -23,6 +23,13 @@ get_sp_bbox <- function(sp){
   return(as.sp_box(xs, ys, proj.string))
 }
 
+
+#' create a spatial polygon from x and y coordinates
+#' 
+#' @param xs a numeric vector of length two, containing the min and max of x values
+#' @param ys a numeric vector of length two, containing the min and max of y values
+#' 
+#' @return a `SpatialPolygons` object
 as.sp_box <- function(xs, ys, proj.string){
   Sr1 <- Polygon(cbind(c(xs[c(1, 2, 2, 1, 1)]), c(ys[c(1, 1, 2, 2, 1)])))
   Srs1 <- Polygons(list(Sr1), "s1")

--- a/viz.yaml
+++ b/viz.yaml
@@ -29,6 +29,11 @@ info:
       version: 0.1.8
       name: USGS-VIZLAB/vizlab
       ref: v0.1.8
+    svglite: 
+      repo: github
+      version: 1.2.0.9002
+      name: jread-usgs/svglite
+      ref: not_tagged_yet
     dplyr: 
       repo: CRAN
       version: 0.7.2

--- a/viz.yaml
+++ b/viz.yaml
@@ -33,7 +33,7 @@ info:
       repo: github
       version: 1.2.0.9002
       name: jread-usgs/svglite
-      ref: not_tagged_yet
+      ref: svgnano_01
     dplyr: 
       repo: CRAN
       version: 0.7.2


### PR DESCRIPTION
I have the following proposal:

I [forked svglite](https://github.com/jread-usgs/svglite) and removed _almost_ all of the extras (styles, defs, css, etc) that we don't use (and end up removing instead).

I suggest that we still use R to make svg skeletons for the maps, and use js to do the fancy stuff. In order to do this, i think we should formalize some code to generate the svgs, and here is a bit of a strawdog. The code isn't fully implemented, but you can (from within `visualize.harvey_map()`) call something like 
```r
get_svg_geoms(counties)
clip_sp is not implemented yet
{xml_nodeset (203)}
 [1] <path d="M 179.76 377.59 L 185.60 377.45 L 186.44 429.69 L 169.35 429.77 L 169.36 424.87 L 167.71 424.86 L 167.65 423.62 L 165.47 423.68 L 165.47 425.01 L 163.43 425.04 L 163.34 423.92 L 153.17 424.20 L 152.52 378.13 L 179.76 377.59 Z"/>
 [2] <path d="M 361.93 233.98 L 366.15 245.23 L 366.53 244.91 L 367.80 245.23 L 368.99 247.12 L 369.10 247.54 L 368.77 247.69 L 368.62 248.05 L 368.28 249.10 L 368.43 249.34 L 368.25 250.00 L 368.93 251.20 L 369.12 252.12 L 369.39 252.54 L 369.80 253. ...
 [3] <path d="M 481.90 235.86 L 503.42 234.52 L 503.68 237.12 L 504.64 250.04 L 504.77 253.62 L 505.56 264.70 L 502.87 264.25 L 501.00 263.49 L 500.33 263.39 L 499.83 263.16 L 498.38 262.76 L 497.88 262.50 L 496.71 262.23 L 495.96 261.84 L 495.50 261. ...
 [4] <path d="M 181.55 461.33 L 201.52 461.02 L 201.70 471.91 L 203.47 472.27 L 203.09 475.13 L 202.89 475.11 L 202.79 476.20 L 203.18 477.45 L 201.97 477.27 L 201.53 480.26 L 201.27 480.21 L 200.96 483.03 L 206.52 483.81 L 206.61 484.04 L 209.32 483. ...
 [5] <path d="M 152.05 339.58 L 152.52 378.13 L 118.45 380.17 L 117.95 340.08 L 152.05 339.58 Z"/>
 [6] <path d="M 344.96 273.05 L 346.65 272.98 L 347.25 272.62 L 348.57 272.69 L 349.26 272.57 L 349.78 271.92 L 349.96 271.83 L 350.65 271.80 L 351.52 271.93 L 352.48 271.72 L 352.99 271.76 L 354.10 272.04 L 354.28 273.09 L 354.63 273.99 L 354.57 274. ...
 [7] <path d="M 201.12 432.85 L 201.93 432.79 L 202.47 432.64 L 202.56 432.49 L 202.65 431.59 L 203.04 431.41 L 204.00 431.20 L 205.68 431.02 L 205.74 430.90 L 205.95 430.84 L 206.69 431.05 L 207.41 430.82 L 207.62 430.97 L 208.46 430.39 L 208.52 430. ...
 [8] <path d="M 520.66 138.82 L 521.16 139.44 L 521.42 139.30 L 521.40 139.04 L 521.51 138.91 L 522.03 139.29 L 522.52 139.10 L 522.74 139.47 L 522.29 139.96 L 522.33 140.13 L 523.01 140.32 L 523.12 140.49 L 523.14 140.73 L 522.84 141.23 L 522.83 141. ...
 [9] <path d="M 462.87 150.07 L 474.22 149.44 L 474.33 149.70 L 476.62 149.55 L 477.23 150.37 L 477.26 150.85 L 478.20 150.77 L 478.26 151.22 L 480.19 151.10 L 480.20 151.61 L 482.09 151.49 L 482.13 151.96 L 483.06 151.92 L 483.11 152.97 L 483.27 153. ...
[10] <path d="M 503.12 231.15 L 503.34 231.19 L 503.59 230.93 L 504.43 230.53 L 504.78 230.68 L 504.92 230.61 L 505.18 230.44 L 505.34 230.19 L 505.84 230.03 L 505.91 229.72 L 506.42 229.38 L 506.79 229.47 L 507.17 229.71 L 507.56 229.68 L 507.91 229. ...
[11] <path d="M 476.17 97.83 L 476.46 98.47 L 476.58 99.27 L 477.11 99.74 L 478.24 101.41 L 478.26 101.71 L 478.00 102.30 L 478.81 103.26 L 479.25 104.21 L 479.28 104.96 L 479.66 105.56 L 479.58 107.21 L 479.27 107.57 L 478.64 108.04 L 479.07 108.51 L ...
[12] <path d="M 160.17 267.21 L 160.29 267.69 L 161.43 267.46 L 162.12 267.73 L 162.63 267.64 L 162.81 267.52 L 162.63 267.31 L 162.60 267.04 L 163.26 267.10 L 163.83 267.46 L 164.13 267.04 L 165.15 266.77 L 165.61 266.29 L 165.82 266.38 L 165.76 266. ...
[13] <path d="M 322.15 147.95 L 326.65 146.42 L 326.47 145.52 L 347.63 141.11 L 347.66 141.26 L 347.94 141.17 L 348.80 142.13 L 349.89 142.05 L 350.13 142.20 L 350.46 141.93 L 351.03 142.18 L 351.60 142.27 L 352.30 142.07 L 353.24 141.38 L 353.63 141. ...
[14] <path d="M 151.58 299.84 L 174.46 308.79 L 181.92 316.72 L 187.39 323.65 L 192.62 329.62 L 179.10 341.42 L 179.01 339.28 L 152.05 339.58 L 151.58 299.84 Z"/>
[15] <path d="M 175.77 461.43 L 181.55 461.33 L 166.41 496.01 L 165.57 496.10 L 165.18 496.34 L 164.79 496.77 L 164.67 496.70 L 164.71 496.16 L 164.56 495.98 L 163.93 496.25 L 163.57 496.03 L 162.97 495.91 L 162.73 496.00 L 162.70 496.15 L 162.88 496. ...
[16] <path d="M 375.38 212.02 L 376.91 212.06 L 381.21 211.85 L 390.37 236.08 L 399.28 235.67 L 400.06 250.47 L 369.12 252.12 L 368.93 251.20 L 368.25 250.00 L 368.43 249.34 L 368.28 249.10 L 368.62 248.05 L 368.77 247.69 L 369.10 247.54 L 368.99 247. ...
[17] <path d="M 295.53 315.52 L 314.84 303.06 L 320.10 297.23 L 321.72 298.77 L 321.02 299.56 L 322.13 300.57 L 322.06 301.12 L 321.63 301.32 L 321.54 301.90 L 321.59 302.53 L 322.15 302.88 L 322.32 303.36 L 322.05 305.18 L 322.22 305.74 L 322.84 306. ...
[18] <path d="M 479.48 181.02 L 479.55 184.23 L 479.71 184.33 L 480.48 199.29 L 471.94 199.73 L 472.63 212.60 L 458.24 213.36 L 457.98 207.79 L 452.21 208.10 L 452.48 213.79 L 438.11 214.63 L 438.17 214.27 L 438.41 214.21 L 438.41 213.97 L 438.76 213. ...
[19] <path d="M 179.10 341.42 L 179.76 377.59 L 152.52 378.13 L 152.05 339.58 L 179.01 339.28 L 179.10 341.42 Z"/>
[20] <path d="M 169.35 429.77 L 168.77 429.79 L 169.08 430.68 L 170.13 430.82 L 170.61 431.71 L 171.26 431.85 L 171.39 437.96 L 172.93 437.96 L 173.01 443.67 L 175.90 443.64 L 175.77 461.43 L 144.28 461.70 L 143.97 430.05 L 153.25 430.04 L 153.17 424. ...
...
```

Being able to separate the elements for each of the different takes away the bulk of the brittle garbage code that is in harvey_map.R, and makes me feel better about the process. So...I haven't yet implemented any changes to the viz that use these utils, but if I did, it would clean up the visualize step a lot. 

Thoughts?



